### PR TITLE
Update propose schema based on community feedback

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,17 @@
+# Developer Notes
+
+These notes are intended for the developers updating this documentation, not users of the JSON schema.
+
+## Installing Json Validator
+
+```bash
+pip3 install jsonschema
+```
+
+## Validating the Examples
+
+```bash
+jsonschema schemas/standardcharges/standardcharges.json -i examples/standardcharges/standardcharges-sample.json
+
+jsonschema schemas/standardcharges/standardcharges.json -i examples/standardcharges/standardcharges-sample-ancillary_charges.json
+```

--- a/examples/standardcharges/standardcharges-sample-ancillary_charges.json
+++ b/examples/standardcharges/standardcharges-sample-ancillary_charges.json
@@ -1,0 +1,51 @@
+{
+  "reporting_entity_name": "St. Bonaventure Hospital",
+  "reporting_entity_medicare_id": "123456",
+  "last_update_on": "2020-01-01",
+  "standardcharges": [
+    {
+      "description": "Arthroplasty, knee condyle and plateau, medial and lateral compartments",
+      "billing_code_type": "CPT",
+      "billing_code_type_version": "2020",
+      "billing_code": "27447",
+      "billing_code_modifier": "LT",
+      "billing_class": "facility",
+      "account_base_class": "outpatient",
+      "revenue_code": 360,
+      "gross_charge": 500.0,
+      "cash_rate": 221.11,
+      "minimum_negotiated_rate": 220.45,
+      "maximum_negotiated_rate": 223.45,
+      "negotiated_rates": [
+        {
+          "payer_name": "Insurance West",
+          "plan_name": "Insurance West PPO",
+          "negotiated_rate": 223.45,
+          "expiration_date": "2022-01-01",
+          "rate_inclusive_of_ancillary_charges": true
+        },
+        {
+          "payer_name": "Insurance West",
+          "plan_name": "Insurance West HMO",
+          "negotiated_rate": 220.45,
+          "expiration_date": "2022-01-01",
+          "rate_inclusive_of_ancillary_charges": true
+        }
+      ],
+      "ancillary_charges": [
+        {
+          "description": "Anesthesia for Arthroplasty",
+          "billing_class": "facility",
+          "revenue_code": 360,
+          "gross_charge": 300.0
+        },
+        {
+          "description": "Tools for Arthroplasty",
+          "billing_class": "facility",
+          "revenue_code": 360,
+          "gross_charge": 100.0
+        }
+      ]
+    }
+  ]
+}

--- a/examples/standardcharges/standardcharges-sample.json
+++ b/examples/standardcharges/standardcharges-sample.json
@@ -8,6 +8,7 @@
       "billing_code_type": "CPT",
       "billing_code_type_version": "2020",
       "billing_code": "27447",
+      "billing_code_modifier": "LT",
       "billing_class": "facility",
       "account_base_class": "outpatient",
       "revenue_code": 360,

--- a/examples/standardcharges/standardcharges-sample.json
+++ b/examples/standardcharges/standardcharges-sample.json
@@ -1,6 +1,6 @@
 {
   "reporting_entity_name": "St. Bonaventure Hospital",
-  "reporting_entity_tin": "11-1111111",
+  "reporting_entity_medicare_id": "123456",
   "last_update_on": "2020-01-01",
   "standardcharges": [
     {

--- a/schemas/standardcharges/README.md
+++ b/schemas/standardcharges/README.md
@@ -3,7 +3,7 @@
 | Field | Name | Type | Definition | Required |
 | ----- | ---- | ---- | ---------- | -------- |
 | **reporting_entity_name** | Entity Name | String | The name of the entity publishing the machine-readable file. | Yes |
-| **reporting_entity_tin** | Tax Identification Number | String | The unique identification number issued either by the Social Security Administration or by the Internal Revenue Service (IRS). | Yes |
+| **reporting_entity_medicare_id** | Medicare CCN | String | The Medicare CCN assigned to the entity. The Medicare CCN is a six character identification number assigned to Medicare and Medicaid providers (also called the Medicare/Medicaid provider number, the Online Survey, Certification And Reporting (OSCAR) number, or the Medicare Identification Number). | Yes |
 | **last_update_on** | Last Update On | String | The date in which the file was last updated. Date must be in an ISO 8601 format (e.g. YYYY-MM-DD) | Yes |
 | **standardcharges** | Standard Charges Object | Array | An array of standardcharges object types | Yes |
 

--- a/schemas/standardcharges/README.md
+++ b/schemas/standardcharges/README.md
@@ -17,6 +17,7 @@ This type defines a standardcharges object.
 | **billing_code_type** | Billing Code Type | String | Allowed values: "CPT", "HCPCS", "ICD", and "DRG". | No |
 | **billing_code_type_version** | Billing Code Type Version | String | There might be versions associated with the `billing_code_type`. For example, Medicare is currently using ICD's version 10 | No |
 | **billing_code** | Billing Code | String | The code used by a plan or issuer or its in-network providers to identify health care items or services for purposes of billing, adjudicating, and paying claims for a covered item or service. | No |
+| **billing_code_modifier** | Billing Code Modifier | String | If applicable, a modifier code assigned to the `billing_code`. This is commonly used with `CPT` codes to clarify what service is being billed. | No |
 | **billing_class** | Billing Class | String | Allowed values: "facility", "professional" | Yes |
 | **account_base_class** | Account Base Class | String | Allowed values: "inpatient", "outpatient", "emergency" | Yes |
 | **revenue_code** | Revenue Code | Number | The hospital revenue code associated with the charge, if applicable. | No |

--- a/schemas/standardcharges/README.md
+++ b/schemas/standardcharges/README.md
@@ -27,6 +27,7 @@ This type defines a standardcharges object.
 | **minimum_negotiated_rate** | Minimum Negotiated Rate | Number | The dollar amount of the lowest negotiated price for the service. | Yes |
 | **maximum_negotiated_rate** | Maximum Negotiated Rate | Number | The dollar amount of the highest negotiated price for the service. | Yes |
 | **negotiated_rates** | Negotiated Rates | Array | This is an array of negotiated rate details object types. | Yes |
+| **ancillary_charges** | Ancillary Charges | Array | This is an optional array of ancillary charge details object types. | No |
 
 
 #### Negotiated Rate Details Object
@@ -39,4 +40,21 @@ This type defines a negotiated rate object.
 | **plan_name** | Plan Name | String | The insurance plan name. | Yes |
 | **negotiated_rate** | Negotiated Rate | Number | The dollar amount negotiated for the service | Yes |
 | **expiration_date** | Expiration Date | String | The date in which the agreement for the `negotiated_price` ends. Date must be in an ISO 8601 format (e.g. YYYY-MM-DD) | No |
+| **rate_inclusive_of_ancillary_charges** | Rate inclusive of ancillary charges? | Boolean | Whether or not the listed rate is inclusive of the listed ancillary charges in the ancillary charges array. | No |
 
+
+#### Ancillary Charge Details Object
+
+This type defines an ancillary charge object. Ancillary charges are charges that often happen in conjunction with the
+listed charge.
+
+| Field | Name | Type | Definition | Required |
+| ----- | ---- | ---- | ---------- | -------- |
+| **description** | Description | String | Brief description of the item/service | Yes |
+| **billing_code_type** | Billing Code Type | String | Allowed values: "CPT", "HCPCS", "ICD", and "DRG". | No |
+| **billing_code_type_version** | Billing Code Type Version | String | There might be versions associated with the `billing_code_type`. For example, Medicare is currently using ICD's version 10 | No |
+| **billing_code** | Billing Code | String | The code used by a plan or issuer or its in-network providers to identify health care items or services for purposes of billing, adjudicating, and paying claims for a covered item or service. | No |
+| **billing_code_modifier** | Billing Code Modifier | String | If applicable, a modifier code assigned to the `billing_code`. This is commonly used with `CPT` codes to clarify what service is being billed. | No |
+| **billing_class** | Billing Class | String | Allowed values: "facility", "professional" | No |
+| **revenue_code** | Revenue Code | Number | The hospital revenue code associated with the charge, if applicable. | No |
+| **gross_charge** | Gross Charge | Number | The dollar amount of the service's gross charge | No |

--- a/schemas/standardcharges/standardcharges.json
+++ b/schemas/standardcharges/standardcharges.json
@@ -22,6 +22,12 @@
           "type": "array",
           "items": { "$ref": "#/definitions/negotiated_rate" },
           "default": []
+        },
+
+        "ancillary_charges": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/ancillary_charge" },
+          "default": []
         }
       },
       "required": ["description", "billing_class", "account_base_class", "gross_charge", "cash_rate", "minimum_negotiated_rate", "maximum_negotiated_rate"]
@@ -33,12 +39,27 @@
         "payer_name": { "type": "string" },
         "plan_name": { "type": "string" },
         "negotiated_rate": { "type": "number" },
-        "expiration_date": { "type": "string", "format": "date" }
+        "expiration_date": { "type": "string", "format": "date" },
+        "rate_inclusive_of_ancillary_charges": { "type": "boolean", "default": false }
       },
       "required": [ "payer_name", "plan_name", "negotiated_rate" ]
+    },
+
+    "ancillary_charge": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "billing_code_type": { "enum": [ "CPT", "HCPCS", "ICD", "DRG" ] },
+        "billing_code_type_version": { "type": "string" },
+        "billing_code": { "type": "string" },
+        "billing_code_modifier": { "type": "string" },
+        "billing_class": { "enum": [ "facility", "professional" ] },
+        "revenue_code": { "type": "number" },
+        "gross_charge": { "type": "number" }
+      },
+      "required": [ "description" ]
     }
   },
-
 
   "type": "object",
 

--- a/schemas/standardcharges/standardcharges.json
+++ b/schemas/standardcharges/standardcharges.json
@@ -8,6 +8,7 @@
         "billing_code_type": { "enum": [ "CPT", "HCPCS", "ICD", "DRG" ] },
         "billing_code_type_version": { "type": "string" },
         "billing_code": { "type": "string" },
+        "billing_code_modifier": { "type": "string" },
         "billing_class": { "enum": [ "facility", "professional" ] },
         "account_base_class": { "enum": [ "inpatient", "outpatient", "emergency" ] },
         "revenue_code": { "type": "number" },

--- a/schemas/standardcharges/standardcharges.json
+++ b/schemas/standardcharges/standardcharges.json
@@ -43,7 +43,7 @@
 
   "properties": {
     "reporting_entity_name": { "type": "string" },
-    "reporting_entity_tin": { "type": "string" },
+    "reporting_entity_medicare_id": { "type": "string" },
     "last_update_on": { "type": "string", "format": "date" },
     "standardcharges": {
       "type": "array",
@@ -51,6 +51,6 @@
       "default": []
     }
   },
-  "required": ["reporting_entity_name", "reporting_entity_tin", "last_update_on", "standardcharges"]
+  "required": ["reporting_entity_name", "reporting_entity_medicare_id", "last_update_on", "standardcharges"]
 
 }


### PR DESCRIPTION
# Description

Update propose schema based on community feedback to handle CPT modifiers, CMS ids, and ancillary charges.

- Replaced `reporting_entity_tin` with `reporting_entity_medicare_id` as it is more appropriate for providers in this context
- Added optional `billing_code_modifier` to enable listing CPT modifiers
- Added support for optionally listing Ancillary Charges and defining if a rate is inclusive of those ancillary charges or not
  - Added optional `ancillary_charges` array to `standardcharge` type, populated by new `ancillary_charge` type
  - Added `rate_inclusive_of_ancillary_charges ` field to `negotiated_rate` type. 
  - Added a new JSON example file for this use case.
 
## Release Notes

- This is a breaking change as required field `reporting_entity_tin` is removed and required field `reporting_entity_medicare_id` is added.

## Testing

- Validated schema changes and validated examples based on the schema.